### PR TITLE
modify-display-for-messages

### DIFF
--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,13 +1,13 @@
 - @group.messages.each do |message|
   .chat__main__message 
-    .chat__main__message__user-info
-      %p.chat__main__message__user-info__user-name
-        = current_user.name
-      %p.chat__main__message__user-info__date
-        = message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S") if message.created_at.present?
-    .chat__main__message__text
-      - if message.body.present?
-        %p.chat__main__message__text__body
-          = message.body 
-      = image_tag message.image_url, class: "chat__main__message__text__image"  if message.image.present?
-
+    - if message.body.present? && message.body.present? 
+      .chat__main__message__user-info
+        %p.chat__main__message__user-info__user-name
+          = current_user.name
+        %p.chat__main__message__user-info__date
+          = message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S") if message.created_at.present?
+      .chat__main__message__text
+        - if message.body.present?
+          %p.chat__main__message__text__body
+            = message.body 
+        = image_tag message.image_url, class: "chat__main__message__text__image"  if message.image.present?


### PR DESCRIPTION
# WHAT
メッセージ投稿失敗時の出力方法を変更する。

# WHY
メッセージ投稿失敗時、一時的に空のメッセージが出力されてしまうため、出力されないように修正。